### PR TITLE
removed redundant line to get 'vagrant up' working on Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         salt.install_master = true
         salt.install_type = 'git'
         salt.install_args = 'v2018.3.2'
-        salt.version = '2018.3.2'
         salt.seed_master = {reggie: 'vagrant/vagrant/files/reggie.pub'}
         salt.master_config = 'vagrant/vagrant/files/salt_master.yaml'
         salt.minion_config = 'vagrant/vagrant/files/salt_minion.yaml'


### PR DESCRIPTION
@RobRuana and I realized that the removed line here is redundant with the line immediately above it and needed to be removed for me to be able to up a fresh environment on my Ubuntu box.  It's not clear why this was actually a problem for me and not for him, but it seems like it shouldn't hurt anything to remove it.