### PR TITLE
fix Vagrantfile for windows (and maybe more platforms) users  [READY FOR MERGE AFTER TESTING ON STAGING] 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,11 @@ Vagrant.require_version '>= 2'
 ENV['EVENT_NAME'] = ENV['EVENT_NAME'] || 'super'
 ENV['EVENT_YEAR'] = ENV['EVENT_YEAR'] || '2019'
 
+if Vagrant::Util::Platform.windows?
+    ENV['IS_VAGRANT_WINDOWS'] = '1'
+else
+    ENV['IS_VAGRANT_WINDOWS'] = '0'
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = 'bento/ubuntu-18.04'
@@ -47,7 +52,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.customize ['setextradata', :id, 'VBoxInternal2/SharedFoldersEnableSymlinksCreate/home_vagrant_reggie-formula', '1']
     end
 
-    config.vm.provision :shell, env: {'EVENT_NAME'=>ENV['EVENT_NAME'], 'EVENT_YEAR'=>ENV['EVENT_YEAR']}, inline: "
+    config.vm.provision :shell, env: {
+        'EVENT_NAME'=>ENV['EVENT_NAME'],
+        'EVENT_YEAR'=>ENV['EVENT_YEAR'],
+        'IS_VAGRANT_WINDOWS'=>ENV['IS_VAGRANT_WINDOWS']
+        }, inline: "
         set -e
 
         # Upgrade all packages to the latest version, commented out because it\'s very slow
@@ -78,6 +87,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         mkdir -p /etc/salt
         echo \"event_name: ${EVENT_NAME}\" >> /etc/salt/grains
         echo \"event_year: ${EVENT_YEAR}\" >> /etc/salt/grains
+        echo \"is_vagrant: 1\" >> /etc/salt/grains
+        echo \"is_vagrant_windows: ${IS_VAGRANT_WINDOWS}\" >> /etc/salt/grains
 "
 
     config.vm.provision :salt do |salt|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :virtualbox do |vb|
         vb.memory = 1536
         vb.cpus = 2
-        vb.name = 'reggie.%s.%s.%s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%-%d.%H.%M.%S.%L')]
+        if (host == windows) then
+            vb.name = 'reggie %s %s %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %s')]
+else if (host == linux) then
+  vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')]
+else if (host == osx) then
+  vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')]
+end if
 
         # Allow symlinks to be created in /home/vagrant/reggie-formula.
         # Modify "home_vagrant_reggie-formula" to be different if you change the path.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,9 +7,9 @@ ENV['EVENT_NAME'] = ENV['EVENT_NAME'] || 'super'
 ENV['EVENT_YEAR'] = ENV['EVENT_YEAR'] || '2019'
 
 if Vagrant::Util::Platform.windows?
-    ENV['IS_VAGRANT_WINDOWS'] = '1'
+    ENV['IS_VAGRANT_WINDOWS'] = 'true'
 else
-    ENV['IS_VAGRANT_WINDOWS'] = '0'
+    ENV['IS_VAGRANT_WINDOWS'] = 'false'
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -87,7 +87,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         mkdir -p /etc/salt
         echo \"event_name: ${EVENT_NAME}\" >> /etc/salt/grains
         echo \"event_year: ${EVENT_YEAR}\" >> /etc/salt/grains
-        echo \"is_vagrant: 1\" >> /etc/salt/grains
         echo \"is_vagrant_windows: ${IS_VAGRANT_WINDOWS}\" >> /etc/salt/grains
 "
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :virtualbox do |vb|
         vb.memory = 1536
         vb.cpus = 2
-        vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')]
+        vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H.%M.%S.%L')]
 
         # Allow symlinks to be created in /home/vagrant/reggie-formula.
         # Modify "home_vagrant_reggie-formula" to be different if you change the path.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :virtualbox do |vb|
         vb.memory = 1536
         vb.cpus = 2
-        vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')]
+        vb.name = 'reggie.%s.%s.%s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%-%d.%H.%M.%S.%L')]
 
         # Allow symlinks to be created in /home/vagrant/reggie-formula.
         # Modify "home_vagrant_reggie-formula" to be different if you change the path.
@@ -79,7 +79,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         salt.install_master = true
         salt.install_type = 'git'
         salt.install_args = 'v2018.3.2'
-        salt.version = '2018.3.2'
+        #salt.version = '2018.3.2'
         salt.seed_master = {reggie: 'vagrant/vagrant/files/reggie.pub'}
         salt.master_config = 'vagrant/vagrant/files/salt_master.yaml'
         salt.minion_config = 'vagrant/vagrant/files/salt_minion.yaml'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,8 +34,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :virtualbox do |vb|
         vb.memory = 1536
         vb.cpus = 2
-        if (host == windows)
-	    # don't use colons (:) or parens in windows filenames, will cause vagrant up to fail
+        if Vagrant::Util::Platform.windows?
+            # don't use colons (:) or parens in windows filenames, will cause vagrant up to fail
             vb.name = 'reggie %s %s %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %s')]
         else
             vb.name = 'reggie (%s %s) %s' % [ENV['EVENT_NAME'], ENV['EVENT_YEAR'], Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         salt.install_master = true
         salt.install_type = 'git'
         salt.install_args = 'v2018.3.2'
-        salt.version = '2018.3.2'
         salt.seed_master = {reggie: 'vagrant/vagrant/files/reggie.pub'}
         salt.master_config = 'vagrant/vagrant/files/salt_master.yaml'
         salt.minion_config = 'vagrant/vagrant/files/salt_minion.yaml'

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -102,12 +102,18 @@ reggie chown {{ reggie.user }} {{ reggie[dir] }}:
       - reggie sideboard git latest
 {%- endfor %}
 
+# note: if running on windows+vagrant, virtualbox's shared win host -> linux vm FS implementation
+# doesn't support symlinks so we need to use VIRTUALENV_ALWAYS_COPY which causes file copies instead of symlinks
 reggie virtualenv:
   virtualenv.managed:
     - name: {{ reggie.install_dir }}/env
     - user: {{ reggie.user }}
     - python: /usr/bin/python3
     - system_site_packages: False
+    {% if grains['IS_VAGRANT_WINDOWS'] == '1' %}
+    - env_vars:
+      - VIRTUALENV_ALWAYS_COPY: 1
+    {% endif %}
     - require:
       - pip: virtualenv
       - reggie chown {{ reggie.user }} {{ reggie.install_dir }}

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -110,7 +110,7 @@ reggie virtualenv:
     - user: {{ reggie.user }}
     - python: /usr/bin/python3
     - system_site_packages: False
-    {% if grains['is_vagrant_windows'] | default(false) %}
+    {% if grains.get('is_vagrant_windows', false) %}
     - env:
       - VIRTUALENV_ALWAYS_COPY: 1
     {% endif %}

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -110,8 +110,8 @@ reggie virtualenv:
     - user: {{ reggie.user }}
     - python: /usr/bin/python3
     - system_site_packages: False
-    {% if grains['IS_VAGRANT_WINDOWS'] == 'true' %}
-    - env_vars:
+    {% if grains['is_vagrant_windows'] | default(false) %}
+    - env:
       - VIRTUALENV_ALWAYS_COPY: 1
     {% endif %}
     - require:

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -3,7 +3,7 @@
 # ============================================================================
 
 {%- from 'reggie/map.jinja' import reggie with context %}
-{%- from 'reggie/macros.jinja' import dump_ini with context %}
+{%- from 'reggie/macros.jinja' import dump_ini, handle_windows_permissions with context %}
 {%- set env = salt['grains.get']('env') %}
 
 
@@ -127,6 +127,7 @@ reggie sideboard configuration:
         {{ dump_ini(reggie.sideboard.config)|indent(8) }}
     - template: jinja
     - show_changes: {% if env == 'dev' %}True{% else %}False{% endif %}
+    {{ handle_windows_permissions() }}
     - require:
       - reggie virtualenv
 
@@ -181,6 +182,7 @@ reggie {{ plugin_id }} configuration:
         {{ dump_ini(plugin.config)|indent(8) }}
     - template: jinja
     - show_changes: {% if env == 'dev' %}True{% else %}False{% endif %}
+    {{ handle_windows_permissions() }}
     - require:
       - reggie {{ plugin_id }} package install
 {% endif %}
@@ -203,6 +205,7 @@ reggie {{ plugin_id }} requirements update:
     - name: {{ absolute_path }}
     - user: {{ reggie.user }}
     - group: {{ reggie.group }}
+    {{ handle_windows_permissions() }}
     {% for key, value in file_spec.items() %}
     {% if key == 'contents' %}
     - contents: |

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -110,7 +110,7 @@ reggie virtualenv:
     - user: {{ reggie.user }}
     - python: /usr/bin/python3
     - system_site_packages: False
-    {% if grains['IS_VAGRANT_WINDOWS'] == '1' %}
+    {% if grains['IS_VAGRANT_WINDOWS'] == 'true' %}
     - env_vars:
       - VIRTUALENV_ALWAYS_COPY: 1
     {% endif %}

--- a/reggie/macros.jinja
+++ b/reggie/macros.jinja
@@ -159,3 +159,11 @@ include:
 
 {{ encode_ini(data) }}
 {%- endmacro -%}
+
+{%- macro handle_windows_permissions() -%}
+    {% if grains['is_vagrant_windows'] | default(false) %}
+    # on windows, in vboxfs shared filesystems (used to share from win->linux), this is unchangable.
+    # set it here so that salt won't fail when it tries to save. kind of a hack, but only on vagrant so... whatever
+    - mode: 0777
+    {% endif %}
+{%- endmacro -%}

--- a/reggie/macros.jinja
+++ b/reggie/macros.jinja
@@ -160,10 +160,15 @@ include:
 {{ encode_ini(data) }}
 {%- endmacro -%}
 
+{#
+    On windows, in vboxfs shared filesystems (used to share from win->linux),
+    we get an error if we try to change the permissions, which salt does by
+    default when it manages a file.  The only exception is that we can set 777
+    permissions without an error.  This macro should be dropped into the middle
+    of e.g. a "file.managed" state to optionally add the mode param.
+#}
 {%- macro handle_windows_permissions() -%}
     {% if grains['is_vagrant_windows'] | default(false) %}
-    # on windows, in vboxfs shared filesystems (used to share from win->linux), this is unchangable.
-    # set it here so that salt won't fail when it tries to save. kind of a hack, but only on vagrant so... whatever
     - mode: 0777
     {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
Fix a bunch of windows-specific issues.

PLEASE TEST ON STAGING FIRST and a fresh linux install if possible.  Should all be OK though.

fixes #8    On windows, Vagrant will instruct virtualbox to try and rename the folder to have the timestamp separate by colon ':' characters, on windows this isn't allowed and causes 'vagrant up' to fail.  This fixes Vagrantfile for windows users.

fixes #10   fixes #9     Extra salt.version line causing issues for some users

fixes #11   Adds fix for windows symlink issue

fixes #13  Fix issue where salt would fail to make permissions stick on windows shared files (which are always 777) and fail the build.