### PR TITLE
Remove old staff_eligible_for_swag_shirt default

### DIFF
--- a/reggie/defaults.yaml
+++ b/reggie/defaults.yaml
@@ -147,7 +147,6 @@ reggie:
 
         out_of_shirts: False
         shirts_per_staffer: 1
-        staff_eligible_for_swag_shirt: False
         separate_staff_merch: False
 
         max_badge_sales: 2000


### PR DESCRIPTION
This was removed with recent changes to how staff and event shirts worked. (https://github.com/magfest/ubersystem/pull/3470)