### PR TITLE
Add is_str to _ordered_decode

### DIFF
--- a/_modules/monkeypatch.py
+++ b/_modules/monkeypatch.py
@@ -13,9 +13,10 @@ def ordered_yaml():
                 keep=False,
                 normalize=False,
                 preserve_dict_class=True,
-                preserve_tuples=False):
+                preserve_tuples=False,
+                to_str=False):
             # Overridden to change default value of preserve_dict_class to True.
-            return _original_decode(data, encoding, errors, keep, normalize, preserve_dict_class, preserve_tuples)
+            return _original_decode(data, encoding, errors, keep, normalize, preserve_dict_class, preserve_tuples, to_str)
         _ordered_decode._patched = True
         salt.utils.data.decode = _ordered_decode
 


### PR DESCRIPTION
Updating salt meant that several functions inside SaltStack now call decode with a `to_str` keyword argument -- we didn't have this implemented, so it broke our ability to run state.apply. This should fix it.