### PR TITLE
Keep using the new NGINX formula

### DIFF
--- a/vagrant/top.sls
+++ b/vagrant/top.sls
@@ -9,7 +9,7 @@ base:
     - glusterfs.server
     - haproxy
     - glusterfs.client
-    - nginx.ng
+    - nginx
     - reggie.web
     - reggie_deploy.web
     - reggie_deploy.sessions


### PR DESCRIPTION
The old NGINX method (called `nginx`) was removed, and the formula we used was renamed to just `nginx`, so we have to update our reference to it.