### PR TITLE
Add ability to set non-master branch for plugins and sideboard

### DIFF
--- a/reggie/defaults.yaml
+++ b/reggie/defaults.yaml
@@ -33,6 +33,7 @@ reggie:
     timeout: 60  # 1 hour (in minutes)
 
   sideboard:
+    branch: master
     config:
       debug: False
       priority_plugins: ['uber']
@@ -57,6 +58,7 @@ reggie:
 
   plugins:
     ubersystem:
+      branch: master
       name: uber
       source: https://github.com/magfest/ubersystem.git
       config:

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -73,8 +73,8 @@ reggie sideboard git latest:
   git.latest:
     - name: https://github.com/magfest/sideboard.git
     - target: {{ reggie.install_dir }}
-    - rev: master
-    - branch: master
+    - rev: {{ reggie.sideboard.branch if reggie.sideboard.get('branch') else 'master' }}
+    - branch: {{ reggie.sideboard.branch if reggie.sideboard.get('branch') else 'master' }}
     - remote: origin
 
 reggie chown {{ reggie.user }} {{ reggie.install_dir }}:
@@ -157,8 +157,8 @@ reggie {{ plugin_id }} git latest:
     - name: {{ plugin.source }}
     - user: {{ reggie.user }}
     - target: {{ reggie.install_dir }}/plugins/{{ plugin.name }}
-    - rev: master
-    - branch: master
+    - rev: {{ plugin.branch if plugin.get('branch') else 'master' }}
+    - branch: {{ plugin.branch if plugin.get('branch') else 'master' }}
     - remote: origin
     - require:
       - reggie {{ previous_plugin_ids[loop.index0] }} requirements update


### PR DESCRIPTION
We need this so we can 'freeze' MAGWest's system to pre-access groups, and also it's nice to have as a feature.