### PR TITLE
bumped salt version to match mcp

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,7 +93,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :salt do |salt|
         salt.install_master = true
         salt.install_type = 'git'
-        salt.install_args = 'v2018.3.2'
+        salt.install_args = 'v2019.2.0'
         salt.seed_master = {reggie: 'vagrant/vagrant/files/reggie.pub'}
         salt.master_config = 'vagrant/vagrant/files/salt_master.yaml'
         salt.minion_config = 'vagrant/vagrant/files/salt_minion.yaml'


### PR DESCRIPTION
I forgot to open this PR last night when I filed the others.  We had to bump our salt version on MCP because of an OpenSSL change, and we need to do the same thing on Vagrant.