### PR TITLE
python3 refactor - dict.keys

### DIFF
--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -148,7 +148,7 @@ reggie sideboard requirements update:
     - require:
       - reggie sideboard package install
 
-{%- set previous_plugin_ids = ['sideboard'] + reggie.plugins.keys() -%}
+{%- set previous_plugin_ids = ['sideboard'] + list(reggie.plugins.keys()) -%}
 
 {% for plugin_id, plugin in reggie.plugins.items() %}
 

--- a/reggie/install/init.sls
+++ b/reggie/install/init.sls
@@ -148,7 +148,7 @@ reggie sideboard requirements update:
     - require:
       - reggie sideboard package install
 
-{%- set previous_plugin_ids = ['sideboard'] + list(reggie.plugins.keys()) -%}
+{%- set previous_plugin_ids = ['sideboard'] + reggie.plugins.keys() -%}
 
 {% for plugin_id, plugin in reggie.plugins.items() %}
 


### PR DESCRIPTION
jinja templates are borken because python3